### PR TITLE
feat(analytics): init GA V1 (basic prompt)

### DIFF
--- a/@types/gtag.d.ts
+++ b/@types/gtag.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Type definitions for Google Analytics gtag
+ */
+
+declare global {
+  interface Window {
+    dataLayer: unknown[];
+    gtag: (...args: unknown[]) => void;
+  }
+}
+
+export {};

--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -5,6 +5,6 @@
     "module": "NodeNext",
     "types": ["node"]
   },
-  "include": ["src/**/*.ts", "@types"],
+  "include": ["src/**/*.ts", "@types", "../../@types"],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/apps/front/app/layout.tsx
+++ b/apps/front/app/layout.tsx
@@ -1,6 +1,8 @@
 import { ToastProvider } from '@app/front/provider/ToastProvider'
 import React from 'react'
 import ReactQueryProvider from '../provider/ReactQueryProvider'
+import { GoogleAnalytics } from '../components/GoogleAnalytics'
+import { PageTracker } from '../components/PageTracker'
 
 export const metadata = {
   title: "Taskly'n Hutch",
@@ -13,10 +15,16 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || ''
+
   return (
     <ReactQueryProvider>
       <html lang="en">
+        <head>
+          <GoogleAnalytics measurementId={gaId} />
+        </head>
         <body>
+          <PageTracker />
           <ToastProvider>{children}</ToastProvider>
         </body>
       </html>

--- a/apps/front/components/GoogleAnalytics.tsx
+++ b/apps/front/components/GoogleAnalytics.tsx
@@ -1,0 +1,32 @@
+import Script from 'next/script';
+
+interface GoogleAnalyticsProps {
+  measurementId: string;
+}
+
+export function GoogleAnalytics({ measurementId }: GoogleAnalyticsProps) {
+  if (!measurementId) return null;
+
+  return (
+    <>
+      <Script
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+      />
+      <Script
+        id="google-analytics"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${measurementId}', {
+              page_path: window.location.pathname,
+            });
+          `,
+        }}
+      />
+    </>
+  );
+}

--- a/apps/front/components/PageTracker.tsx
+++ b/apps/front/components/PageTracker.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { usePageTracking } from '../hooks/usePageTracking';
+
+/**
+ * Component that tracks page views using Google Analytics
+ * This is a client component that should be included in the layout
+ */
+export function PageTracker() {
+  // Use the page tracking hook
+  usePageTracking();
+  
+  // This component doesn't render anything
+  return null;
+}

--- a/apps/front/hooks/usePageTracking.ts
+++ b/apps/front/hooks/usePageTracking.ts
@@ -1,0 +1,22 @@
+import { trackPageView } from '@taskly/shared'
+import { usePathname, useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
+
+/**
+ * Hook to track page views in Google Analytics
+ * Automatically tracks page views when the route changes
+ */
+export const usePageTracking = (): void => {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    if (pathname) {
+      // Construct the full URL including search parameters
+      const url = searchParams?.size ? `${pathname}?${searchParams.toString()}` : pathname
+
+      // Track the page view
+      trackPageView(url)
+    }
+  }, [pathname, searchParams])
+}

--- a/apps/front/tsconfig.app.json
+++ b/apps/front/tsconfig.app.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -23,12 +19,6 @@
       }
     ]
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "../../@types"],
+  "exclude": ["node_modules"]
 }

--- a/libs/shared/src/analytics/index.ts
+++ b/libs/shared/src/analytics/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Analytics utility functions for tracking page views and events
+ */
+
+/**
+ * Track a page view in Google Analytics
+ * @param url The URL to track
+ */
+export const trackPageView = (url: string): void => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('config', process.env['NEXT_PUBLIC_GA_MEASUREMENT_ID'] as string, {
+      page_path: url,
+    });
+  }
+};
+
+/**
+ * Track a custom event in Google Analytics
+ * @param action The action name
+ * @param params Additional event parameters
+ */
+export const trackEvent = (action: string, params: Record<string, unknown> = {}): void => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', action, params);
+  }
+};

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/schemas'
+export * from './analytics'

--- a/libs/shared/tsconfig.json
+++ b/libs/shared/tsconfig.json
@@ -6,7 +6,6 @@
     "noPropertyAccessFromIndexSignature": true
   },
   "files": [],
-  "include": [],
   "references": [
     {
       "path": "./tsconfig.lib.json"

--- a/libs/shared/tsconfig.lib.json
+++ b/libs/shared/tsconfig.lib.json
@@ -5,6 +5,6 @@
     "declaration": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "../../@types"],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libs/shared/tsconfig.spec.json
+++ b/libs/shared/tsconfig.spec.json
@@ -10,6 +10,7 @@
     "jest.config.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "../../@types/gtag.d.ts"
   ]
 }


### PR DESCRIPTION
This is a test with a basic prompt from Windsurf:

```
i would like to add google analytics to my front to track page views
```

It cost 2 User Prompts and 22 Flow actions Credits.