### PR TITLE
feat(analytics): add GA with better AI prompt

### DIFF
--- a/apps/front/app/layout.tsx
+++ b/apps/front/app/layout.tsx
@@ -1,6 +1,7 @@
 import { ToastProvider } from '@app/front/provider/ToastProvider'
 import React from 'react'
 import ReactQueryProvider from '../provider/ReactQueryProvider'
+import { GoogleAnalytics } from '../components/GoogleAnalytics'
 
 export const metadata = {
   title: "Taskly'n Hutch",
@@ -16,6 +17,9 @@ export default async function RootLayout({
   return (
     <ReactQueryProvider>
       <html lang="en">
+        <head>
+          <GoogleAnalytics />
+        </head>
         <body>
           <ToastProvider>{children}</ToastProvider>
         </body>

--- a/apps/front/components/GoogleAnalytics.tsx
+++ b/apps/front/components/GoogleAnalytics.tsx
@@ -1,0 +1,55 @@
+/**
+ * Google Analytics script component for Next.js
+ */
+'use client';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+import Script from 'next/script';
+import { useEffect } from 'react';
+import { trackView } from '../core/analytics';
+
+export function GoogleAnalytics() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const measurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+  // Track page views when the route changes
+  useEffect(() => {
+    if (!measurementId) return;
+    
+    // Combine pathname and search params for full URL tracking
+    const url = pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : '');
+    
+    // Track the page view
+    trackView(url);
+  }, [pathname, searchParams, measurementId]);
+
+  // Only render the GA script if we have a measurement ID
+  if (!measurementId) return null;
+
+  return (
+    <>
+      {/* Google Analytics Script */}
+      <Script
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+      />
+      <Script
+        id="google-analytics"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${measurementId}', {
+              page_path: window.location.pathname,
+            });
+          `,
+        }}
+      />
+    </>
+  );
+}
+
+export default GoogleAnalytics;

--- a/apps/front/core/analytics.ts
+++ b/apps/front/core/analytics.ts
@@ -1,0 +1,65 @@
+/**
+ * Google Analytics service for tracking page views
+ */
+export class Analytics {
+  private static instance: Analytics;
+  private measurementId: string | null = null;
+
+  private constructor() {
+    // Initialize with the measurement ID from environment variables
+    this.measurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || null;
+  }
+
+  /**
+   * Get the singleton instance of Analytics
+   */
+  public static getInstance(): Analytics {
+    if (!Analytics.instance) {
+      Analytics.instance = new Analytics();
+    }
+    return Analytics.instance;
+  }
+
+  /**
+   * Track a page view in Google Analytics
+   * @param path - The path of the page being viewed
+   */
+  public trackView(path: string): void {
+    if (!this.measurementId) {
+      console.error('Google Analytics Measurement ID is not configured');
+      return;
+    }
+
+    // Only execute in browser environment
+    if (typeof window !== 'undefined') {
+      // Push to dataLayer if gtag is available
+      if (window.gtag) {
+        window.gtag('config', this.measurementId, {
+          page_path: path,
+        });
+      }
+    }
+  }
+}
+
+// Declare global gtag function
+declare global {
+  interface Window {
+    gtag: (command: string, measurementId?: string, config?: Record<string, unknown>) => void;
+  }
+}
+
+/**
+ * Get the Analytics instance
+ */
+export const getAnalytics = (): Analytics => {
+  return Analytics.getInstance();
+};
+
+/**
+ * Track a page view
+ * @param path - The path of the page being viewed
+ */
+export const trackView = (path: string): void => {
+  getAnalytics().trackView(path);
+};


### PR DESCRIPTION
This the V2 version of adding Google Analytics using AI only, this time using a more advanced prompt
```
Add google analytics to my website, only track page views, you will create a new class into apps/front/core/analytics.ts, create a function called trackView.
You'll track them into @layout.tsx 
```

It cost 1 User Credit and 5 Flow Actions Credits